### PR TITLE
Add "/transactions/{safe_address}/propose" and allow POST requests

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -12,7 +12,7 @@ interface Params {
 export function callEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
-  parameters?: paths[T]['get']['parameters'] | paths[T]['post']['parameters'],
+  parameters?: paths[T]['get']['parameters'],
   rawUrl?: string,
 ): Promise<paths[T]['get']['responses'][200]['schema']> {
   let url = rawUrl

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -6,21 +6,24 @@ type Primitive = string | number | boolean | null
 interface Params {
   path?: { [key: string]: Primitive }
   query?: { [key: string]: Primitive }
+  body?: unknown
 }
 
 export function callEndpoint<T extends keyof paths>(
   baseUrl: string,
   path: T,
-  parameters?: paths[T]['get']['parameters'],
+  parameters?: paths[T]['get']['parameters'] | paths[T]['post']['parameters'],
   rawUrl?: string,
 ): Promise<paths[T]['get']['responses'][200]['schema']> {
   let url = rawUrl
+  let body
   if (!url) {
     const params = parameters as Params
     const pathname = insertParams(path, params?.path)
     const search = stringifyQuery(params?.query)
     url = `${baseUrl}${pathname}${search}`
+    body = params?.body
   }
 
-  return fetchJson(url)
+  return fetchJson(url, body)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { callEndpoint } from './endpoint'
 import { operations, definitions } from './types/gateway'
-import { MultisigTransactionRequest } from './types/transactions'
 
 export type GatewayDefinitions = definitions
 
@@ -49,10 +48,10 @@ export function getTransactionQueue(baseUrl: string, address: string, pageUrl?: 
   )
 }
 
-export function postTransaction(baseUrl: string, address: string, body: MultisigTransactionRequest) {
+export function postTransaction(baseUrl: string, address: string, body: operations['post_transaction']['parameters']['body']) {
   return callEndpoint(
     baseUrl,
-    'transactions/{safe_address}/propose',
+    '/transactions/{safe_address}/propose',
     { path: { safe_address: address }, body },
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { callEndpoint } from './endpoint'
 import { operations, definitions } from './types/gateway'
+import { MultisigTransactionRequest } from './types/transactions'
 
 export type GatewayDefinitions = definitions
 
@@ -45,6 +46,14 @@ export function getTransactionQueue(baseUrl: string, address: string, pageUrl?: 
     '/safes/{safe_address}/transactions/queued',
     { path: { safe_address: address }, query: {} },
     pageUrl,
+  )
+}
+
+export function postTransaction(baseUrl: string, address: string, body: MultisigTransactionRequest) {
+  return callEndpoint(
+    baseUrl,
+    'transactions/{safe_address}/propose',
+    { path: { safe_address: address }, body },
   )
 }
 

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -49,7 +49,7 @@ export interface paths {
     }
   }
   '/transactions/{safe_address}/propose': {
-    post: operations['post_transaction']
+    get: operations['post_transaction']
     parameters: {
       path: {
         safe_address: string
@@ -236,12 +236,9 @@ export interface operations {
       body: MultisigTransactionRequest
     }
     responses: {
-      /* Empty response */
-      200: unknown
-      /** Safe not found */
-      404: unknown
-      /** Safe address checksum not valid */
-      422: unknown
+      200: {
+        schema: unknown
+      }
     }
   }
 }

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -1,4 +1,4 @@
-import { TransactionListItem } from './transactions'
+import { TransactionListItem, MultisigTransactionRequest } from './transactions'
 
 export interface paths {
   '/safes/{address}/': {
@@ -42,6 +42,14 @@ export interface paths {
   }
   '/safes/{safe_address}/transactions/queued': {
     get: operations['queued_transactions']
+    parameters: {
+      path: {
+        safe_address: string
+      }
+    }
+  }
+  '/transactions/{safe_address}/propose': {
+    post: operations['post_transaction']
     parameters: {
       path: {
         safe_address: string
@@ -218,6 +226,22 @@ export interface operations {
       200: {
         schema: definitions['TransactionListPage']
       }
+    }
+  }
+  post_transaction: {
+    parameters: {
+      path: {
+        safe_address: string
+      }
+      body: MultisigTransactionRequest
+    }
+    responses: {
+      /* Empty response */
+      200: unknown
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
     }
   }
 }

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -49,6 +49,7 @@ export interface paths {
     }
   }
   '/transactions/{safe_address}/propose': {
+    /** This is actually supposed to be POST but it breaks our type paradise */
     get: operations['post_transaction']
     parameters: {
       path: {

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -240,6 +240,10 @@ export interface operations {
       200: {
         schema: unknown
       }
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
     }
   }
 }

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -215,3 +215,20 @@ export type ConflictHeader = {
 }
 
 export type TransactionListItem = Transaction | Label | ConflictHeader
+
+export interface MultisigTransactionRequest {
+  to: string;
+  value: string;
+  data: string | null;
+  nonce: string;
+  operation: Operation;
+  safeTxGas: string;
+  baseGas: string;
+  gasPrice: string;
+  gasToken: string;
+  refundReceiver: string | null;
+  safeTxHash: string;
+  sender: string;
+  signature: string;
+  origin: string | null;
+}

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -217,18 +217,18 @@ export type ConflictHeader = {
 export type TransactionListItem = Transaction | Label | ConflictHeader
 
 export interface MultisigTransactionRequest {
-  to: string;
-  value: string;
-  data: string | null;
-  nonce: string;
-  operation: Operation;
-  safeTxGas: string;
-  baseGas: string;
-  gasPrice: string;
-  gasToken: string;
-  refundReceiver: string | null;
-  safeTxHash: string;
-  sender: string;
-  signature: string;
-  origin: string | null;
+  to: string
+  value: string
+  data: string | null
+  nonce: string
+  operation: Operation
+  safeTxGas: string
+  baseGas: string
+  gasPrice: string
+  gasToken: string
+  refundReceiver: string | null
+  safeTxHash: string
+  sender: string
+  signature: string | null
+  origin: string | null
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import fetch from 'unfetch'
 
-export type Params = { [key: string]: string | number | boolean | null }
+export type Params = Record<string, string | number | boolean | null>
 
 function replaceParam(str: string, key: string, value: string): string {
   return str.replace(new RegExp(`\\{${key}\\}`, 'g'), value)
@@ -30,19 +30,20 @@ export function stringifyQuery(query?: Params): string {
 }
 
 export function fetchJson<T>(url: string, body?: unknown): Promise<T> {
-  let bodyStr: string | undefined | null
-  if (body != null && typeof body !== 'string') {
-    bodyStr = JSON.stringify(body)
-  } else {
-    bodyStr = body as string | null | undefined
+  let options: {
+    method: 'POST',
+    headers: Record<string, string>,
+		body: string
+  } | undefined
+  if (body != null) {
+    options = {
+      method: 'POST',
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' }
+    }
   }
 
-  return fetch(url, {
-    body: bodyStr,
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  }).then((resp) => {
+  return fetch(url, options).then((resp) => {
     if (!resp.ok) {
       throw Error(resp.statusText)
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,8 +29,20 @@ export function stringifyQuery(query?: Params): string {
   return searchString ? `?${searchString}` : ''
 }
 
-export function fetchJson<T>(url: string): Promise<T> {
-  return fetch(url).then((resp) => {
+export function fetchJson<T>(url: string, body?: unknown): Promise<T> {
+  let bodyStr: string | undefined | null
+  if (body != null && typeof body !== 'string') {
+    bodyStr = JSON.stringify(body)
+  } else {
+    bodyStr = body as string | null | undefined
+  }
+
+  return fetch(url, {
+    body: bodyStr,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }).then((resp) => {
     if (!resp.ok) {
       throw Error(resp.statusText)
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function fetchJson<T>(url: string, body?: unknown): Promise<T> {
   let options: {
     method: 'POST',
     headers: Record<string, string>,
-		body: string
+    body: string
   } | undefined
   if (body != null) {
     options = {

--- a/tests/endpoint.test.js
+++ b/tests/endpoint.test.js
@@ -14,7 +14,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.xdai.staging.gnosisdev.com/v1', '/balances/supported-fiat-codes')
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.xdai.staging.gnosisdev.com/v1/balances/supported-fiat-codes')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.xdai.staging.gnosisdev.com/v1/balances/supported-fiat-codes', undefined)
   })
 
   it('should accept a path param', () => {
@@ -22,7 +22,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/safe/{address}', { path: { address: '0x123' } })
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123', undefined)
   })
 
   it('should accept several path params', () => {
@@ -30,7 +30,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' } })
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd', undefined)
   })
 
   it('should accept query params', () => {
@@ -38,7 +38,31 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } })
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd?exclude_spam=true')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd?exclude_spam=true', undefined)
+  })
+
+  it('should accept body', () => {
+    expect(
+      callEndpoint(
+        'https://safe-client.rinkeby.staging.gnosisdev.com/v1',
+        '/transactions/{safe_address}/propose',
+        {
+          path: { safe_address: '0x123' },
+          body: { test: 'test' }
+        }
+      )
+    ).resolves.toEqual({ success: true })
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://safe-client.rinkeby.staging.gnosisdev.com/v1/transactions/0x123/propose',
+      {
+        method: 'POST',
+        body: '{"test":"test"}',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
   })
 
   it('should accept a raw URL', () => {
@@ -46,6 +70,6 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } }, '/test-url?raw=true')
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('/test-url?raw=true')
+    expect(fetch).toHaveBeenCalledWith('/test-url?raw=true', undefined)
   })
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -48,7 +48,26 @@ describe('utils', () => {
       })
 
       expect(fetchJson('/test/safe?q=123')).resolves.toEqual({ success: true })
-      expect(fetch).toHaveBeenCalledWith('/test/safe?q=123')
+      expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
+    })
+
+    it('should make a post request', () => {
+      fetch.mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ success: true })
+        })
+      })
+
+      expect(fetchJson('/test/safe', '123')).resolves.toEqual({ success: true })
+
+      expect(fetch).toHaveBeenCalledWith('/test/safe', {
+        method: 'POST',
+        body: '123',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
     })
 
     it('should throw if response is not OK', () => {
@@ -60,7 +79,7 @@ describe('utils', () => {
       })
 
       expect(fetchJson('/test/safe?q=123')).rejects.toThrow('Failed')
-      expect(fetch).toHaveBeenCalledWith('/test/safe?q=123')
+      expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
     })
   })
 })


### PR DESCRIPTION
Adding an endpoint to create Safe transactions – `transactions/{safe_address}/propose`.

We've been only doing GET requests so far, so some changes to support POST requests were needed.