### PR TITLE
Feature: export transaction types from index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { callEndpoint } from './endpoint'
 import { operations, definitions } from './types/gateway'
+export * from './types/transactions'
 
 export type GatewayDefinitions = definitions
 


### PR DESCRIPTION
Because transaction types were not imported from index, we had to copy them to src/types in safe-react and if we tried to do `import { Operation, TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk/dist/types/transactions'` webpack was not happy with it for some reason.

This way it works perfectly, tested it on my local machine