### PR TITLE
Fallback to a text response if JSON fails

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: reviewdog/action-eslint
+      - uses: reviewdog/action-eslint@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,5 +11,6 @@ jobs:
       - uses: mattallty/jest-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI: true
         with:
           test-command: 'echo done'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm install
+      - run: npm test
       - uses: mattallty/jest-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          test-command: 'echo done'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,4 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: mattallty/jest-github-action
+      - uses: mattallty/jest-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yalc.lock
 tsconfig.tsbuildinfo
 /openapi
 .#*
+jest.results.json

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "build": "rm -rf dist && webpack --mode production",
     "prepare": "yarn build",
     "prettier": "prettier -w",
-    "test": "jest tests/"
+    "test:watch": "jest tests/ --watch",
+    "test": "jest --coverage --json --outputFile='jest.results.json' ./tests"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepare": "yarn build",
     "prettier": "prettier -w",
     "test:watch": "jest tests/ --watch",
-    "test": "jest --coverage --json --outputFile='jest.results.json' ./tests"
+    "test": "jest --ci --coverage --json --outputFile='jest.results.json' ./tests"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,4 +1,4 @@
-import { fetchJson, insertParams, stringifyQuery } from './utils'
+import { fetchData, insertParams, stringifyQuery } from './utils'
 import { paths } from './types/gateway'
 
 type Primitive = string | number | boolean | null
@@ -25,5 +25,5 @@ export function callEndpoint<T extends keyof paths>(
     body = params?.body
   }
 
-  return fetchJson(url, body)
+  return fetchData(url, body)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,12 +48,12 @@ export function getTransactionQueue(baseUrl: string, address: string, pageUrl?: 
   )
 }
 
-export function postTransaction(baseUrl: string, address: string, body: operations['post_transaction']['parameters']['body']) {
-  return callEndpoint(
-    baseUrl,
-    '/transactions/{safe_address}/propose',
-    { path: { safe_address: address }, body },
-  )
+export function postTransaction(
+  baseUrl: string,
+  address: string,
+  body: operations['post_transaction']['parameters']['body'],
+) {
+  return callEndpoint(baseUrl, '/transactions/{safe_address}/propose', { path: { safe_address: address }, body })
 }
 
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,24 +29,31 @@ export function stringifyQuery(query?: Params): string {
   return searchString ? `?${searchString}` : ''
 }
 
-export function fetchJson<T>(url: string, body?: unknown): Promise<T> {
-  let options: {
-    method: 'POST',
-    headers: Record<string, string>,
-    body: string
-  } | undefined
+export async function fetchJson<T>(url: string, body?: unknown): Promise<T> {
+  let options:
+    | {
+        method: 'POST'
+        headers: Record<string, string>
+        body: string
+      }
+    | undefined
   if (body != null) {
     options = {
       method: 'POST',
       body: typeof body === 'string' ? body : JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json' }
+      headers: { 'Content-Type': 'application/json' },
     }
   }
 
-  return fetch(url, options).then((resp) => {
-    if (!resp.ok) {
-      throw Error(resp.statusText)
-    }
-    return resp.json()
-  })
+  const resp = await fetch(url, options)
+
+  if (!resp.ok) {
+    throw Error(resp.statusText)
+  }
+
+  try {
+    return await resp.json()
+  } catch (err) {
+    return (await resp.text()) as unknown as T
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export function stringifyQuery(query?: Params): string {
   return searchString ? `?${searchString}` : ''
 }
 
-export async function fetchJson<T>(url: string, body?: unknown): Promise<T> {
+export async function fetchData<T>(url: string, body?: unknown): Promise<T> {
   let options:
     | {
         method: 'POST'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,9 +51,11 @@ export async function fetchJson<T>(url: string, body?: unknown): Promise<T> {
     throw Error(resp.statusText)
   }
 
-  try {
-    return await resp.json()
-  } catch (err) {
-    return (await resp.text()) as unknown as T
+  // If the reponse is empty, don't try to parse it
+  const text = await resp.text()
+  if (!text) {
+    return text as unknown as T
   }
+
+  return resp.json()
 }

--- a/tests/endpoint.test.js
+++ b/tests/endpoint.test.js
@@ -1,12 +1,15 @@
-import fetch from 'unfetch'
+import { fetchJson } from '../src/utils'
 import { callEndpoint } from '../src/endpoint'
 
-jest.mock('unfetch', () => jest.fn(() => {
-  return Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({ success: true })
-  })
-}))
+jest.mock('../src/utils', () => {
+  const originalModule = jest.requireActual('../src/utils')
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    fetchJson: jest.fn(() => Promise.resolve({ success: true }))
+  }
+})
 
 describe('callEndpoint', () => {
   it('should accept just a path', () => {
@@ -14,7 +17,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.xdai.staging.gnosisdev.com/v1', '/balances/supported-fiat-codes')
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.xdai.staging.gnosisdev.com/v1/balances/supported-fiat-codes', undefined)
+    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.xdai.staging.gnosisdev.com/v1/balances/supported-fiat-codes', undefined)
   })
 
   it('should accept a path param', () => {
@@ -22,7 +25,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/safe/{address}', { path: { address: '0x123' } })
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123', undefined)
+    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123', undefined)
   })
 
   it('should accept several path params', () => {
@@ -30,7 +33,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' } })
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd', undefined)
+    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd', undefined)
   })
 
   it('should accept query params', () => {
@@ -38,7 +41,7 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } })
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd?exclude_spam=true', undefined)
+    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd?exclude_spam=true', undefined)
   })
 
   it('should accept body', () => {
@@ -53,15 +56,9 @@ describe('callEndpoint', () => {
       )
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(fetchJson).toHaveBeenCalledWith(
       'https://safe-client.rinkeby.staging.gnosisdev.com/v1/transactions/0x123/propose',
-      {
-        method: 'POST',
-        body: '{"test":"test"}',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }
+      { test: 'test' }
     )
   })
 
@@ -70,6 +67,6 @@ describe('callEndpoint', () => {
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } }, '/test-url?raw=true')
     ).resolves.toEqual({ success: true })
 
-    expect(fetch).toHaveBeenCalledWith('/test-url?raw=true', undefined)
+    expect(fetchJson).toHaveBeenCalledWith('/test-url?raw=true', undefined)
   })
 })

--- a/tests/endpoint.test.js
+++ b/tests/endpoint.test.js
@@ -12,8 +12,8 @@ jest.mock('../src/utils', () => {
 })
 
 describe('callEndpoint', () => {
-  it('should accept just a path', () => {
-    expect(
+  it('should accept just a path', async () => {
+    await expect(
       callEndpoint('https://safe-client.xdai.staging.gnosisdev.com/v1', '/balances/supported-fiat-codes'),
     ).resolves.toEqual({ success: true })
 
@@ -23,8 +23,8 @@ describe('callEndpoint', () => {
     )
   })
 
-  it('should accept a path param', () => {
-    expect(
+  it('should accept a path param', async () => {
+    await expect(
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/safe/{address}', {
         path: { address: '0x123' },
       }),
@@ -33,8 +33,8 @@ describe('callEndpoint', () => {
     expect(fetchData).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123', undefined)
   })
 
-  it('should accept several path params', () => {
-    expect(
+  it('should accept several path params', async () => {
+    await expect(
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', {
         path: { address: '0x123', currency: 'usd' },
       }),
@@ -46,8 +46,8 @@ describe('callEndpoint', () => {
     )
   })
 
-  it('should accept query params', () => {
-    expect(
+  it('should accept query params', async () => {
+    await expect(
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', {
         path: { address: '0x123', currency: 'usd' },
         query: { exclude_spam: true },
@@ -60,8 +60,8 @@ describe('callEndpoint', () => {
     )
   })
 
-  it('should accept body', () => {
-    expect(
+  it('should accept body', async () => {
+    await expect(
       callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/transactions/{safe_address}/propose', {
         path: { safe_address: '0x123' },
         body: { test: 'test' },
@@ -74,8 +74,8 @@ describe('callEndpoint', () => {
     )
   })
 
-  it('should accept a raw URL', () => {
-    expect(
+  it('should accept a raw URL', async () => {
+    await expect(
       callEndpoint(
         'https://safe-client.rinkeby.staging.gnosisdev.com/v1',
         '/balances/{address}/{currency}',

--- a/tests/endpoint.test.js
+++ b/tests/endpoint.test.js
@@ -1,4 +1,4 @@
-import { fetchJson } from '../src/utils'
+import { fetchData } from '../src/utils'
 import { callEndpoint } from '../src/endpoint'
 
 jest.mock('../src/utils', () => {
@@ -7,66 +7,83 @@ jest.mock('../src/utils', () => {
   return {
     __esModule: true,
     ...originalModule,
-    fetchJson: jest.fn(() => Promise.resolve({ success: true }))
+    fetchData: jest.fn(() => Promise.resolve({ success: true })),
   }
 })
 
 describe('callEndpoint', () => {
   it('should accept just a path', () => {
     expect(
-      callEndpoint('https://safe-client.xdai.staging.gnosisdev.com/v1', '/balances/supported-fiat-codes')
+      callEndpoint('https://safe-client.xdai.staging.gnosisdev.com/v1', '/balances/supported-fiat-codes'),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.xdai.staging.gnosisdev.com/v1/balances/supported-fiat-codes', undefined)
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://safe-client.xdai.staging.gnosisdev.com/v1/balances/supported-fiat-codes',
+      undefined,
+    )
   })
 
   it('should accept a path param', () => {
     expect(
-      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/safe/{address}', { path: { address: '0x123' } })
+      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/safe/{address}', {
+        path: { address: '0x123' },
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123', undefined)
+    expect(fetchData).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/safe/0x123', undefined)
   })
 
   it('should accept several path params', () => {
     expect(
-      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' } })
+      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', {
+        path: { address: '0x123', currency: 'usd' },
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd', undefined)
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd',
+      undefined,
+    )
   })
 
   it('should accept query params', () => {
     expect(
-      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } })
+      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', {
+        path: { address: '0x123', currency: 'usd' },
+        query: { exclude_spam: true },
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchJson).toHaveBeenCalledWith('https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd?exclude_spam=true', undefined)
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://safe-client.rinkeby.staging.gnosisdev.com/v1/balances/0x123/usd?exclude_spam=true',
+      undefined,
+    )
   })
 
   it('should accept body', () => {
     expect(
-      callEndpoint(
-        'https://safe-client.rinkeby.staging.gnosisdev.com/v1',
-        '/transactions/{safe_address}/propose',
-        {
-          path: { safe_address: '0x123' },
-          body: { test: 'test' }
-        }
-      )
+      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/transactions/{safe_address}/propose', {
+        path: { safe_address: '0x123' },
+        body: { test: 'test' },
+      }),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchJson).toHaveBeenCalledWith(
+    expect(fetchData).toHaveBeenCalledWith(
       'https://safe-client.rinkeby.staging.gnosisdev.com/v1/transactions/0x123/propose',
-      { test: 'test' }
+      { test: 'test' },
     )
   })
 
   it('should accept a raw URL', () => {
     expect(
-      callEndpoint('https://safe-client.rinkeby.staging.gnosisdev.com/v1', '/balances/{address}/{currency}', { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } }, '/test-url?raw=true')
+      callEndpoint(
+        'https://safe-client.rinkeby.staging.gnosisdev.com/v1',
+        '/balances/{address}/{currency}',
+        { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } },
+        '/test-url?raw=true',
+      ),
     ).resolves.toEqual({ success: true })
 
-    expect(fetchJson).toHaveBeenCalledWith('/test-url?raw=true', undefined)
+    expect(fetchData).toHaveBeenCalledWith('/test-url?raw=true', undefined)
   })
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -31,20 +31,20 @@ describe('utils', () => {
   })
 
   describe('fetchData', () => {
-    it('should fetch a simple url', () => {
+    it('should fetch a simple url', async () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('{"success": "true"}'),
-          json: () => Promise.resolve({ success: true }),
+          json: () => Promise.resolve({ success: false }),
         })
       })
 
-      expect(fetchData('/test/safe?q=123')).resolves.toEqual({ success: true })
+      await expect(fetchData('/test/safe?q=123')).resolves.toEqual({ success: true })
       expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
     })
 
-    it('should make a post request', () => {
+    it('should make a post request', async () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
@@ -53,7 +53,7 @@ describe('utils', () => {
         })
       })
 
-      expect(fetchData('/test/safe', '123')).resolves.toEqual({ success: true })
+      await expect(fetchData('/test/safe', '123')).resolves.toEqual({ success: true })
 
       expect(fetch).toHaveBeenCalledWith('/test/safe', {
         method: 'POST',
@@ -64,7 +64,7 @@ describe('utils', () => {
       })
     })
 
-    it('should throw if response is not OK', () => {
+    it('should throw if response is not OK', async () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: false,
@@ -72,11 +72,11 @@ describe('utils', () => {
         })
       })
 
-      expect(fetchData('/test/safe?q=123')).rejects.toThrow('Failed')
+      await expect(fetchData('/test/safe?q=123')).rejects.toThrow('Failed')
       expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
     })
 
-    it('should fallback to raw text if no JSON in response', () => {
+    it('should fallback to raw text if no JSON in response', async () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
@@ -85,7 +85,7 @@ describe('utils', () => {
         })
       })
 
-      expect(fetchData('/propose', 123)).resolves.toEqual('')
+      await expect(fetchData('/propose', 123)).resolves.toEqual('')
     })
   })
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -36,7 +36,7 @@ describe('utils', () => {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('{"success": "true"}'),
-          json: () => Promise.resolve({ success: false }),
+          json: () => Promise.resolve({ success: true }),
         })
       })
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -43,6 +43,7 @@ describe('utils', () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
+          text: () => Promise.resolve('{"success": "true"}'),
           json: () => Promise.resolve({ success: true })
         })
       })
@@ -55,6 +56,7 @@ describe('utils', () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
+          text: () => Promise.resolve('{"success": "true"}'),
           json: () => Promise.resolve({ success: true })
         })
       })
@@ -80,6 +82,18 @@ describe('utils', () => {
 
       expect(fetchJson('/test/safe?q=123')).rejects.toThrow('Failed')
       expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
+    })
+
+    it('should fallback to raw text if no JSON in response', () => {
+      fetch.mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(''),
+          json: () => Promise.reject('Unexpected end of JSON input')
+        })
+      })
+
+      expect(fetchJson('/propose', 123)).resolves.toEqual('')
     })
   })
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,33 +1,25 @@
 import fetch from 'unfetch'
-import { fetchJson, insertParams, stringifyQuery } from '../src/utils'
+import { fetchData, insertParams, stringifyQuery } from '../src/utils'
 
 jest.mock('unfetch')
 
 describe('utils', () => {
   describe('insertParams', () => {
     it('should insert a param into a string', () => {
-      expect(
-        insertParams('/{network}/safe/{address}', { address: '0x0' })
-      ).toBe(
-        '/{network}/safe/0x0'
-      )
+      expect(insertParams('/{network}/safe/{address}', { address: '0x0' })).toBe('/{network}/safe/0x0')
     })
 
     it('should insert several params into a string', () => {
-      expect(
-        insertParams('/{network}/safe/{address}', { address: '0x0', network: 'rinkeby' })
-      ).toBe(
-        '/rinkeby/safe/0x0'
+      expect(insertParams('/{network}/safe/{address}', { address: '0x0', network: 'rinkeby' })).toBe(
+        '/rinkeby/safe/0x0',
       )
     })
   })
 
   describe('stringifyQuery', () => {
     it('should stringify query params', () => {
-      expect(
-        stringifyQuery({ spam: true, page: 11, name: 'token', exclude: null })
-      ).toBe(
-        '?spam=true&page=11&name=token'
+      expect(stringifyQuery({ spam: true, page: 11, name: 'token', exclude: null })).toBe(
+        '?spam=true&page=11&name=token',
       )
     })
 
@@ -38,17 +30,17 @@ describe('utils', () => {
     })
   })
 
-  describe('fetchJson', () => {
+  describe('fetchData', () => {
     it('should fetch a simple url', () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('{"success": "true"}'),
-          json: () => Promise.resolve({ success: true })
+          json: () => Promise.resolve({ success: true }),
         })
       })
 
-      expect(fetchJson('/test/safe?q=123')).resolves.toEqual({ success: true })
+      expect(fetchData('/test/safe?q=123')).resolves.toEqual({ success: true })
       expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
     })
 
@@ -57,18 +49,18 @@ describe('utils', () => {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('{"success": "true"}'),
-          json: () => Promise.resolve({ success: true })
+          json: () => Promise.resolve({ success: true }),
         })
       })
 
-      expect(fetchJson('/test/safe', '123')).resolves.toEqual({ success: true })
+      expect(fetchData('/test/safe', '123')).resolves.toEqual({ success: true })
 
       expect(fetch).toHaveBeenCalledWith('/test/safe', {
         method: 'POST',
         body: '123',
         headers: {
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       })
     })
 
@@ -76,11 +68,11 @@ describe('utils', () => {
       fetch.mockImplementation(() => {
         return Promise.resolve({
           ok: false,
-          statusText: 'Failed'
+          statusText: 'Failed',
         })
       })
 
-      expect(fetchJson('/test/safe?q=123')).rejects.toThrow('Failed')
+      expect(fetchData('/test/safe?q=123')).rejects.toThrow('Failed')
       expect(fetch).toHaveBeenCalledWith('/test/safe?q=123', undefined)
     })
 
@@ -89,11 +81,11 @@ describe('utils', () => {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve(''),
-          json: () => Promise.reject('Unexpected end of JSON input')
+          json: () => Promise.reject('Unexpected end of JSON input'),
         })
       })
 
-      expect(fetchJson('/propose', 123)).resolves.toEqual('')
+      expect(fetchData('/propose', 123)).resolves.toEqual('')
     })
   })
 })


### PR DESCRIPTION
As it turned out in https://github.com/gnosis/safe-react/pull/2615, when the gateway responds to the `/propose` request, the response is empty and thus cannot be parsed as JSON.

This PR adds a fallback to the response text.