### PR TITLE
Fix typo in SafeAppInfo type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -200,11 +200,7 @@ export type TransactionSummary = {
   txStatus: TransactionStatus
   txInfo: TransactionInfo
   executionInfo?: ExecutionInfo
-  safeAppInfo?: {
-    name: string
-    url: string
-    logoUrl: string
-  }
+  safeAppInfo?: SafeAppInfo
 }
 
 export type Transaction = {


### PR DESCRIPTION
There was a typo in one of SafeAppInfo types. We are going to unify the used type and ensure we are using the correct one

For instance `logoUrl` should be `logoUri` as correctly defined by the type that we already have for SafeAppInfo