### PR TITLE
Added guard property to SafeAppInfo

### DIFF
--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -92,6 +92,7 @@ export interface definitions {
     owners: StringValue[]
     implementation: StringValue
     modules: StringValue[]
+    guard: StringValue
     fallbackHandler: StringValue
     version: string
     collectiblesTag: string


### PR DESCRIPTION
Added guard property since [this issue](https://github.com/gnosis/safe-react/issues/2397) requires it