### PR TITLE
Add chainId in SafeInfo

### DIFF
--- a/e2e/safes-read.test.ts
+++ b/e2e/safes-read.test.ts
@@ -7,6 +7,7 @@ describe('getSafeInfo tests', () => {
     const data = await getSafeInfo(config.baseUrl, '4', address)
 
     expect(data.address.value).toBe(address)
+    expect(data.chainId).toBe('4')
     expect(data.guard).toBe(null)
     // Nonce should match any positive integer number over 0
     expect(data.nonce).toBeGreaterThanOrEqual(0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -112,6 +112,7 @@ type Page<T> = {
 
 export type SafeInfo = {
   address: StringValue
+  chainId: string
   nonce: number
   threshold: number
   owners: StringValue[]


### PR DESCRIPTION
A new field `chainId` was added in https://github.com/gnosis/safe-client-gateway/issues/656

This PR updates the corresponding SDK type and bumps the package version.

To be used in https://github.com/gnosis/safe-react/issues/2849