### PR TITLE
Refactor exported types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,5 +1,5 @@
 import { fetchData, insertParams, stringifyQuery } from './utils'
-import { paths } from './types/gateway'
+import { paths } from './types/api'
 
 type Primitive = string | number | boolean | null
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,9 @@
 import { callEndpoint } from './endpoint'
-import {
-  FiatCurrencies,
-  operations,
-  OwnedSafes,
-  SafeBalanceResponse,
-  SafeCollectibleResponse,
-  SafeInfo,
-  TransactionListPage,
-} from './types/gateway'
-import { SafeTransactionEstimation, TransactionDetails } from './types/transactions'
+import { operations } from './types/api'
+import { SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
+import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './types/common'
 export * from './types/transactions'
-export * as GatewayDefinitions from './types/gateway'
+export * from './types/common'
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,10 +1,10 @@
+import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './common'
 import {
   MultisigTransactionRequest,
-  TokenType,
   TransactionDetails,
-  TransactionListItem,
   SafeTransactionEstimation,
   SafeTransactionEstimationRequest,
+  TransactionListPage,
 } from './transactions'
 
 export interface paths {
@@ -99,70 +99,6 @@ export interface paths {
     }
   }
 }
-
-type StringValue = {
-  value: string
-}
-
-type Page<T> = {
-  next?: string
-  previous?: string
-  results: Array<T>
-}
-
-export type SafeInfo = {
-  address: StringValue
-  chainId: string
-  nonce: number
-  threshold: number
-  owners: StringValue[]
-  implementation: StringValue
-  modules: StringValue[]
-  guard: StringValue
-  fallbackHandler: StringValue
-  version: string
-  collectiblesTag: string
-  txQueuedTag: string
-  txHistoryTag: string
-}
-
-export type FiatCurrencies = string[]
-
-export type OwnedSafes = { safes: string[] }
-
-export type TokenInfo = {
-  type: TokenType
-  address: string
-  decimals: number
-  symbol: string
-  name: string
-  logoUri: string | null
-}
-
-export type SafeBalanceResponse = {
-  fiatTotal: string
-  items: Array<{
-    tokenInfo: TokenInfo
-    balance: string
-    fiatBalance: string
-    fiatConversion: string
-  }>
-}
-
-export type SafeCollectibleResponse = {
-  address: string
-  tokenName: string
-  tokenSymbol: string
-  logoUri: string
-  id: string
-  uri: string
-  name: string
-  description: string
-  imageUri: string
-  metadata: { [key: string]: string }
-}
-
-export type TransactionListPage = Page<TransactionListItem>
 
 export interface operations {
   /** Get status of the safe */

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,44 @@
+import { AddressEx, TokenInfo } from './transactions'
+
+export type SafeInfo = {
+  address: AddressEx
+  chainId: string
+  nonce: number
+  threshold: number
+  owners: AddressEx[]
+  implementation: AddressEx
+  modules: AddressEx[]
+  guard: AddressEx
+  fallbackHandler: AddressEx
+  version: string
+  collectiblesTag: string
+  txQueuedTag: string
+  txHistoryTag: string
+}
+
+export type FiatCurrencies = string[]
+
+export type OwnedSafes = { safes: string[] }
+
+export type SafeBalanceResponse = {
+  fiatTotal: string
+  items: Array<{
+    tokenInfo: TokenInfo
+    balance: string
+    fiatBalance: string
+    fiatConversion: string
+  }>
+}
+
+export type SafeCollectibleResponse = {
+  address: string
+  tokenName: string
+  tokenSymbol: string
+  logoUri: string
+  id: string
+  uri: string
+  name: string
+  description: string
+  imageUri: string
+  metadata: { [key: string]: string }
+}

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -222,6 +222,14 @@ export type ConflictHeader = {
 
 export type TransactionListItem = Transaction | Label | ConflictHeader
 
+type Page<T> = {
+  next?: string
+  previous?: string
+  results: Array<T>
+}
+
+export type TransactionListPage = Page<TransactionListItem>
+
 export type MultisigTransactionRequest = {
   to: string
   value: string


### PR DESCRIPTION
We were previously exporting one big `GatewayDefinitions` interface, now it's broken down into small types, individually exported from the package index.

This'll break the imports in safe-react, so I'm also bumping the middle version.