### PR TITLE
chore: Add txId to TransactionDetails type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -303,6 +303,7 @@ export type MultisigExecutionDetails = {
 export type DetailedExecutionInfo = ModuleExecutionDetails | MultisigExecutionDetails
 
 export type TransactionDetails = {
+  txId: string
   executedAt: number | null
   txStatus: TransactionStatus
   txInfo: TransactionInfo


### PR DESCRIPTION
## What it solves
[Transaction deeplinking](https://github.com/gnosis/safe-react/issues/970) preparation

## How this PR fixes it
The transaction `txId` has been added to the endpoint in order for us to load a specific transaction from the Redux store.