### PR TITLE
Add missing `type`s to `TransactionListItem`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -206,6 +206,7 @@ export type TransactionSummary = {
 export type Transaction = {
   transaction: TransactionSummary
   conflictType: 'None' | 'HasNext' | 'End'
+  type: 'TRANSACTION'
 }
 
 export type DateLabel = {

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -211,14 +211,17 @@ export type Transaction = {
 
 export type DateLabel = {
   timestamp: number
+  type: 'DATE_LABEL'
 }
 
 export type Label = {
   label: string
+  type: 'LABEL'
 }
 
 export type ConflictHeader = {
   nonce: number
+  type: 'CONFLICT_HEADER'
 }
 
 export type TransactionListItem = Transaction | Label | ConflictHeader


### PR DESCRIPTION
The transaction reducer required casting due to this missing `type` key. By adding it, it allows the removal of the casting.