### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Previous merge did not take into account the branch was outdated and the version needs to be bumped again.