### PR TITLE
Add safeAppsRpcUri type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -70,6 +70,7 @@ export type ChainInfo = {
   l2: boolean
   description: string
   rpcUri: RpcUri
+  safeAppsRpcUri: RpcUri
   blockExplorerUriTemplate: BlockExplorerUriTemplate
   nativeCurrency: NativeCurrency
   theme: Theme


### PR DESCRIPTION
The `/chains` returned `safeAppsRpcUri` type has been added to the `ChainInfo` type.