### PR TITLE
Add publicRpcUri to ChainInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -71,6 +71,7 @@ export type ChainInfo = {
   description: string
   rpcUri: RpcUri
   safeAppsRpcUri: RpcUri
+  publicRpcUri: RpcUri
   blockExplorerUriTemplate: BlockExplorerUriTemplate
   nativeCurrency: NativeCurrency
   theme: Theme


### PR DESCRIPTION
In accordance with the newly deployed CGW. The `publicRpcUri` has been added to the `ChainInfo` type.