### PR TITLE
Chore: rm unused ERC1155 feature flag

### DIFF
--- a/src/types/chains.ts
+++ b/src/types/chains.ts
@@ -53,7 +53,6 @@ export type GasPrice = (GasPriceOracle | GasPriceFixed | GasPriceUnknown)[]
 
 export enum FEATURES {
   ERC721 = 'ERC721',
-  ERC1155 = 'ERC1155',
   SAFE_APPS = 'SAFE_APPS',
   CONTRACT_INTERACTION = 'CONTRACT_INTERACTION',
   DOMAIN_LOOKUP = 'DOMAIN_LOOKUP',


### PR DESCRIPTION
It wasn't used by safe-react and thus deleted.