### PR TITLE
Added Safe Apps List endpoint

### DIFF
--- a/e2e/get-chains-config.test.ts
+++ b/e2e/get-chains-config.test.ts
@@ -33,7 +33,7 @@ describe('getChainsConfig & getChainConfig tests', () => {
 
       expect(mainnetConfig).toBeDefined()
       expect(mainnetConfig.chainId).toBe(mainnetChainId)
-      expect(mainnetConfig.chainName).toBe('Mainnet')
+      expect(mainnetConfig.chainName).toBe('Ethereum')
       expect(mainnetConfig.shortName).toBe('eth')
       expect(mainnetConfig.l2).toBe(false)
 

--- a/e2e/get-owned-safes.test.ts
+++ b/e2e/get-owned-safes.test.ts
@@ -1,7 +1,7 @@
 import { getOwnedSafes } from '../src'
 import config from './config'
 
-describe('getOwnedSages tests', () => {
+describe('getOwnedSafes tests', () => {
   it('should get owned safes on rinkeby', async () => {
     const data = await getOwnedSafes(config.baseUrl, '4', '0x661E1CF4aAAf6a95C89EA8c81D120E6c62adDFf9')
 
@@ -18,6 +18,6 @@ describe('getOwnedSages tests', () => {
 
   it('should throw for bad addresses', async () => {
     const req = getOwnedSafes(config.baseUrl, '4', '0x661E1CF4aAAf6a95C89EA8c81D120E6c62adDfF9')
-    await expect(req).rejects.toThrow('1: Checksum address validation failed')
+    await expect(req).rejects.toThrow(/Checksum address validation failed/)
   })
 })

--- a/e2e/get-safe-apps.test.ts
+++ b/e2e/get-safe-apps.test.ts
@@ -1,0 +1,25 @@
+import { getSafeApps } from '../src'
+import config from './config'
+
+const rinkebyChainId = '4'
+
+describe('getSafeApps tests', () => {
+  it('Returns Safe Apps List', async () => {
+    const safeAppsList = await getSafeApps(config.baseUrl, rinkebyChainId)
+
+    expect(safeAppsList).toBeDefined()
+    expect(Array.isArray(safeAppsList)).toBe(true)
+
+    // safe app WalletConnect should be present
+    const walletConnectSafeApp = safeAppsList.find((safeApp) => safeApp.name === 'WalletConnect')
+    expect(walletConnectSafeApp).toBeDefined()
+
+    // safe app Transaction Builder should be present
+    const transactionBuilder = safeAppsList.find((safeApp) => safeApp.name === 'Transaction Builder')
+    expect(transactionBuilder).toBeDefined()
+
+    // safe app Drain Safe should be present
+    const drainSafeApp = safeAppsList.find((safeApp) => safeApp.name === 'Drain Account')
+    expect(drainSafeApp).toBeDefined()
+  })
+})

--- a/e2e/post-safe-gas-estimation.test.ts
+++ b/e2e/post-safe-gas-estimation.test.ts
@@ -10,7 +10,7 @@ describe('postSafeGasEstimation tests', () => {
       operation: 0,
     })
 
-    expect(result.safeTxGas).toBe('43663')
+    expect(result.safeTxGas).toBe('45006')
     // Nonce should match any positive integer number over 0
     expect(result.latestNonce).toBeGreaterThanOrEqual(0)
   })

--- a/e2e/propose-transaction.test.ts
+++ b/e2e/propose-transaction.test.ts
@@ -2,7 +2,8 @@ import { proposeTransaction } from '../src'
 import config from './config'
 
 describe('proposeTransaction tests', () => {
-  it('should propose a transaction and fail', async () => {
+  // Skipping this test, see https://github.com/gnosis/safe-client-gateway/issues/745
+  it.skip('should propose a transaction and fail', async () => {
     const req = proposeTransaction(config.baseUrl, '4', '0x4f9BD57BCC68Bf7770429F137922B3afD23d83E7', {
       to: '0x49d4450977E2c95362C13D3a31a09311E0Ea26A6',
       value: '0',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { operations } from './types/api'
 import { SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
 import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './types/common'
 import { ChainListResponse, ChainInfo } from './types/chains'
+import { SafeAppsResponse } from './types/safe-apps'
+export * from './types/safe-apps'
 export * from './types/transactions'
 export * from './types/chains'
 export * from './types/common'
@@ -152,6 +154,15 @@ export function getChainsConfig(
  */
 export function getChainConfig(baseUrl: string, chainId: string): Promise<ChainInfo> {
   return callEndpoint(baseUrl, '/chains/{chainId}/', {
+    path: { chainId: chainId },
+  })
+}
+
+/**
+ * Returns Safe Apps List
+ */
+export function getSafeApps(baseUrl: string, chainId: string): Promise<SafeAppsResponse> {
+  return callEndpoint(baseUrl, '/chains/{chainId}/safe-apps', {
     path: { chainId: chainId },
   })
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7,6 +7,7 @@ import {
   TransactionListPage,
 } from './transactions'
 import { ChainListResponse, ChainInfo } from './chains'
+import { SafeAppsResponse } from './safe-apps'
 
 export interface paths {
   '/chains/{chainId}/safes/{address}/': {
@@ -111,6 +112,14 @@ export interface paths {
   }
   '/chains/{chainId}/': {
     get: operations['chains_read']
+    parameters: {
+      path: {
+        chainId: string
+      }
+    }
+  }
+  '/chains/{chainId}/safe-apps': {
+    get: operations['safe_apps_read']
     parameters: {
       path: {
         chainId: string
@@ -321,6 +330,19 @@ export interface operations {
     responses: {
       200: {
         schema: ChainInfo
+      }
+    }
+  }
+  safe_apps_read: {
+    parameters: {
+      path: {
+        /** A unique value identifying this chain. */
+        chainId: string
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeAppsResponse
       }
     }
   }

--- a/src/types/safe-apps.ts
+++ b/src/types/safe-apps.ts
@@ -1,0 +1,16 @@
+export type SafeAppProvider = {
+  url: string
+  name: string
+}
+
+export type SafeAppData = {
+  id: number
+  url: string
+  name: string
+  iconUrl: string
+  description: string
+  chainIds: string[]
+  provider?: SafeAppProvider
+}
+
+export type SafeAppsResponse = [SafeAppData]


### PR DESCRIPTION
Currently the web app is using the config service directly to fetch the Safe Apps list.

This PR adds the Safe Apps List endpoint to the React Gateway SDK.

Ticket: https://github.com/gnosis/safe-react-gateway-sdk/issues/21

Added minor fixes in other unrelated e2e tests.
