### PR TITLE
Revert types to follow that of OpenAPI

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,18 +1,28 @@
-import { fetchData, stringifyQuery } from './utils'
+import { fetchData, insertParams, stringifyQuery } from './utils'
+import { paths } from './types/api'
 
 type Primitive = string | number | boolean | null
 
 interface Params {
+  path?: { [key: string]: Primitive }
   query?: { [key: string]: Primitive }
   body?: unknown
 }
 
-export function callEndpoint<T>(url: string, params?: Params, rawUrl?: string): Promise<T> {
+export function callEndpoint<T extends keyof paths>(
+  baseUrl: string,
+  path: T,
+  parameters?: paths[T]['get']['parameters'],
+  rawUrl?: string,
+): Promise<paths[T]['get']['responses'][200]['schema']> {
   if (rawUrl) {
     return fetchData(rawUrl)
   }
 
+  const params = parameters as Params
+  const pathname = insertParams(path, params?.path)
   const search = stringifyQuery(params?.query)
-  const endpoint = `${url}${search}`
-  return fetchData(endpoint, params?.body)
+  const url = `${baseUrl}${pathname}${search}`
+
+  return fetchData(url, params?.body)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,10 @@
 import { callEndpoint } from './endpoint'
-import {
-  MultisigTransactionRequest,
-  SafeTransactionEstimation,
-  SafeTransactionEstimationRequest,
-  TransactionDetails,
-  TransactionListPage,
-} from './types/transactions'
+import { operations } from './types/api'
+import { SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
 import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './types/common'
-import { MasterCopyReponse } from './types/master-copies'
 import { ChainListResponse, ChainInfo } from './types/chains'
 import { SafeAppsResponse } from './types/safe-apps'
+import { MasterCopyReponse } from './types/master-copies'
 import { DecodedDataResponse } from './types/decoded-data'
 export * from './types/safe-apps'
 export * from './types/transactions'
@@ -22,7 +17,7 @@ export * from './types/common'
  * Get basic information about a Safe. E.g. owners, modules, version etc
  */
 export function getSafeInfo(baseUrl: string, chainId: string, address: string): Promise<SafeInfo> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safes/${address}/`)
+  return callEndpoint(baseUrl, '/chains/{chainId}/safes/{address}/', { path: { chainId, address } })
 }
 
 /**
@@ -33,12 +28,10 @@ export function getBalances(
   chainId: string,
   address: string,
   currency = 'usd',
-  query: {
-    trusted?: boolean // Return trusted tokens
-    exclude_spam?: boolean // Return spam tokens
-  } = {},
+  query: operations['safes_balances_list']['parameters']['query'] = {},
 ): Promise<SafeBalanceResponse> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safes/${address}/balances/${currency}/`, {
+  return callEndpoint(baseUrl, '/chains/{chainId}/safes/{address}/balances/{currency}/', {
+    path: { chainId, address, currency },
     query,
   })
 }
@@ -47,14 +40,14 @@ export function getBalances(
  * Get a list of supported fiat currencies (e.g. USD, EUR etc)
  */
 export function getFiatCurrencies(baseUrl: string): Promise<FiatCurrencies> {
-  return callEndpoint(`${baseUrl}/balances/supported-fiat-codes`)
+  return callEndpoint(baseUrl, '/balances/supported-fiat-codes')
 }
 
 /**
  * Get the addresses of all Safes belonging to an owner
  */
 export function getOwnedSafes(baseUrl: string, chainId: string, address: string): Promise<OwnedSafes> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/owners/${address}/safes`)
+  return callEndpoint(baseUrl, '/chains/{chainId}/owners/{address}/safes', { path: { chainId, address } })
 }
 
 /**
@@ -64,12 +57,9 @@ export function getCollectibles(
   baseUrl: string,
   chainId: string,
   address: string,
-  query: {
-    trusted?: boolean // Return trusted tokens
-    exclude_spam?: boolean // Return spam tokens
-  } = {},
+  query: operations['safes_collectibles_list']['parameters']['query'] = {},
 ): Promise<SafeCollectibleResponse[]> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safes/${address}/collectibles/`, { query })
+  return callEndpoint(baseUrl, '/chains/{chainId}/safes/{address}/collectibles/', { path: { chainId, address }, query })
 }
 
 /**
@@ -78,10 +68,15 @@ export function getCollectibles(
 export function getTransactionHistory(
   baseUrl: string,
   chainId: string,
-  safeAddress: string,
+  address: string,
   pageUrl?: string,
 ): Promise<TransactionListPage> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safes/${safeAddress}/transactions/history`, undefined, pageUrl)
+  return callEndpoint(
+    baseUrl,
+    '/chains/{chainId}/safes/{safe_address}/transactions/history',
+    { path: { chainId, safe_address: address }, query: {} },
+    pageUrl,
+  )
 }
 
 /**
@@ -90,10 +85,15 @@ export function getTransactionHistory(
 export function getTransactionQueue(
   baseUrl: string,
   chainId: string,
-  safeAddress: string,
+  address: string,
   pageUrl?: string,
 ): Promise<TransactionListPage> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safes/${safeAddress}/transactions/queued`, undefined, pageUrl)
+  return callEndpoint(
+    baseUrl,
+    '/chains/{chainId}/safes/{safe_address}/transactions/queued',
+    { path: { chainId, safe_address: address }, query: {} },
+    pageUrl,
+  )
 }
 
 /**
@@ -104,7 +104,9 @@ export function getTransactionDetails(
   chainId: string,
   transactionId: string,
 ): Promise<TransactionDetails> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/transactions/${transactionId}`)
+  return callEndpoint(baseUrl, '/chains/{chainId}/transactions/{transactionId}', {
+    path: { chainId, transactionId },
+  })
 }
 
 /**
@@ -113,10 +115,11 @@ export function getTransactionDetails(
 export function postSafeGasEstimation(
   baseUrl: string,
   chainId: string,
-  safeAddress: string,
-  body: SafeTransactionEstimationRequest,
+  address: string,
+  body: operations['post_safe_gas_estimation']['parameters']['body'],
 ): Promise<SafeTransactionEstimation> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safes/${safeAddress}/multisig-transactions/estimations`, {
+  return callEndpoint(baseUrl, '/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations', {
+    path: { chainId, safe_address: address },
     body,
   })
 }
@@ -127,10 +130,11 @@ export function postSafeGasEstimation(
 export function proposeTransaction(
   baseUrl: string,
   chainId: string,
-  safeAddress: string,
-  body: MultisigTransactionRequest,
+  address: string,
+  body: operations['propose_transaction']['parameters']['body'],
 ): Promise<TransactionDetails> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/transactions/${safeAddress}/propose`, {
+  return callEndpoint(baseUrl, '/chains/{chainId}/transactions/{safe_address}/propose', {
+    path: { chainId, safe_address: address },
     body,
   })
 }
@@ -140,13 +144,9 @@ export function proposeTransaction(
  */
 export function getChainsConfig(
   baseUrl: string,
-  query?: {
-    ordering?: string
-    limit?: number
-    offset?: number
-  },
+  query?: operations['chains_list']['parameters']['query'],
 ): Promise<ChainListResponse> {
-  return callEndpoint(`${baseUrl}/chains/`, {
+  return callEndpoint(baseUrl, '/chains/', {
     query,
   })
 }
@@ -155,31 +155,40 @@ export function getChainsConfig(
  * Returns a chain config
  */
 export function getChainConfig(baseUrl: string, chainId: string): Promise<ChainInfo> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/`)
+  return callEndpoint(baseUrl, '/chains/{chainId}/', {
+    path: { chainId: chainId },
+  })
 }
 
 /**
  * Returns Safe Apps List
  */
 export function getSafeApps(baseUrl: string, chainId: string): Promise<SafeAppsResponse> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/safe-apps`)
+  return callEndpoint(baseUrl, '/chains/{chainId}/safe-apps', {
+    path: { chainId: chainId },
+  })
 }
 
 /**
- * Returns List of Master Copies
+ * Returns list of Master Copies
  */
 export function getMasterCopies(baseUrl: string, chainId: string): Promise<MasterCopyReponse> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/about/master-copies`)
+  return callEndpoint(baseUrl, '/chains/{chainId}/about/master-copies', {
+    path: { chainId: chainId },
+  })
 }
 
 /**
  * Returns decoded data
  */
-export function getDecodedData(baseUrl: string, chainId: string, encodedData: string): Promise<DecodedDataResponse> {
-  return callEndpoint(`${baseUrl}/chains/${chainId}/data-decoder`, {
-    body: {
-      data: encodedData,
-    },
+export function getDecodedData(
+  baseUrl: string,
+  chainId: string,
+  encodedData: operations['data_decoder']['parameters']['body']['data'],
+): Promise<DecodedDataResponse> {
+  return callEndpoint(baseUrl, '/chains/{chainId}/data-decoder', {
+    path: { chainId: chainId },
+    body: { data: encodedData },
   })
 }
 /* eslint-enable @typescript-eslint/explicit-module-boundary-types */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,394 @@
+import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './common'
+import {
+  MultisigTransactionRequest,
+  TransactionDetails,
+  SafeTransactionEstimation,
+  SafeTransactionEstimationRequest,
+  TransactionListPage,
+} from './transactions'
+import { ChainListResponse, ChainInfo } from './chains'
+import { SafeAppsResponse } from './safe-apps'
+import { DecodedDataRequest, DecodedDataResponse } from './decoded-data'
+import { MasterCopyReponse } from './master-copies'
+
+export interface paths {
+  '/chains/{chainId}/safes/{address}/': {
+    /** Get status of the safe */
+    get: operations['safes_read']
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+      }
+    }
+  }
+  '/chains/{chainId}/safes/{address}/balances/{currency}/': {
+    get: operations['safes_balances_list']
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+        currency: string
+      }
+    }
+  }
+  '/balances/supported-fiat-codes': {
+    get: operations['get_supported_fiat']
+    parameters: null
+  }
+  '/chains/{chainId}/safes/{address}/collectibles/': {
+    /** Get collectibles (ERC721 tokens) and information about them */
+    get: operations['safes_collectibles_list']
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+      }
+    }
+  }
+  '/chains/{chainId}/safes/{safe_address}/transactions/history': {
+    get: operations['history_transactions']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/chains/{chainId}/safes/{safe_address}/transactions/queued': {
+    get: operations['queued_transactions']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/chains/{chainId}/transactions/{transactionId}': {
+    get: operations['get_transactions']
+    parameters: {
+      path: {
+        chainId: string
+        transactionId: string
+      }
+    }
+  }
+  '/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations': {
+    /** This is actually supposed to be POST but it breaks our type paradise */
+    get: operations['post_safe_gas_estimation']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/chains/{chainId}/transactions/{safe_address}/propose': {
+    /** This is actually supposed to be POST but it breaks our type paradise */
+    get: operations['propose_transaction']
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+    }
+  }
+  '/chains/{chainId}/owners/{address}/safes': {
+    get: operations['get_owned_safes']
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+      }
+    }
+  }
+  '/chains/': {
+    get: operations['chains_list']
+    parameters: {
+      query: {
+        ordering?: string
+        limit?: number
+        offset?: number
+      }
+    }
+  }
+  '/chains/{chainId}/': {
+    get: operations['chains_read']
+    parameters: {
+      path: {
+        chainId: string
+      }
+    }
+  }
+  '/chains/{chainId}/safe-apps': {
+    get: operations['safe_apps_read']
+    parameters: {
+      path: {
+        chainId: string
+      }
+    }
+  }
+  '/chains/{chainId}/about/master-copies': {
+    get: operations['master_copies']
+    parameters: {
+      path: {
+        chainId: string
+      }
+    }
+  }
+  '/chains/{chainId}/data-decoder': {
+    get: operations['data_decoder']
+    parameters: {
+      path: {
+        chainId: string
+      }
+    }
+  }
+}
+
+export interface operations {
+  /** Get status of the safe */
+  safes_read: {
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeInfo
+      }
+      /** Safe not found */
+      404: unknown
+      /**
+       * code = 1: Checksum address validation failed
+       * code = 50: Cannot get Safe info
+       */
+      422: unknown
+    }
+  }
+  /** Get balance for Ether and ERC20 tokens with USD fiat conversion */
+  safes_balances_list: {
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+        currency: string
+      }
+      query: {
+        /** If `True` just trusted tokens will be returned */
+        trusted?: boolean
+        /** If `True` spam tokens will not be returned */
+        exclude_spam?: boolean
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeBalanceResponse
+      }
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
+    }
+  }
+  get_supported_fiat: {
+    parameters: null
+    responses: {
+      200: {
+        schema: FiatCurrencies
+      }
+    }
+  }
+  /** Get collectibles (ERC721 tokens) and information about them */
+  safes_collectibles_list: {
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+      }
+      query: {
+        /** If `True` just trusted tokens will be returned */
+        trusted?: boolean
+        /** If `True` spam tokens will not be returned */
+        exclude_spam?: boolean
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeCollectibleResponse[]
+      }
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
+    }
+  }
+  history_transactions: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      query: {
+        /** Taken from the Page['next'] or Page['previous'] */
+        page_url?: string
+      }
+    }
+    responses: {
+      200: {
+        schema: TransactionListPage
+      }
+    }
+  }
+  queued_transactions: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      query: {
+        /** Taken from the Page['next'] or Page['previous'] */
+        page_url?: string
+      }
+    }
+    responses: {
+      200: {
+        schema: TransactionListPage
+      }
+    }
+  }
+  get_transactions: {
+    parameters: {
+      path: {
+        chainId: string
+        transactionId: string
+      }
+    }
+    responses: {
+      200: {
+        schema: TransactionDetails
+      }
+    }
+  }
+  post_safe_gas_estimation: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      body: SafeTransactionEstimationRequest
+    }
+    responses: {
+      200: {
+        schema: SafeTransactionEstimation
+      }
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
+    }
+  }
+  propose_transaction: {
+    parameters: {
+      path: {
+        chainId: string
+        safe_address: string
+      }
+      body: MultisigTransactionRequest
+    }
+    responses: {
+      200: {
+        schema: TransactionDetails
+      }
+      /** Safe not found */
+      404: unknown
+      /** Safe address checksum not valid */
+      422: unknown
+    }
+  }
+  get_owned_safes: {
+    parameters: {
+      path: {
+        chainId: string
+        address: string
+      }
+    }
+    responses: {
+      200: {
+        schema: OwnedSafes
+      }
+    }
+  }
+  chains_list: {
+    parameters: {
+      query?: {
+        /** Which field to use when ordering the results. */
+        ordering?: string
+        /** Number of results to return per page. */
+        limit?: number
+        /** The initial index from which to return the results. */
+        offset?: number
+      }
+    }
+    responses: {
+      200: {
+        schema: ChainListResponse
+      }
+    }
+  }
+  chains_read: {
+    parameters: {
+      path: {
+        /** A unique value identifying this chain. */
+        chainId: string
+      }
+    }
+    responses: {
+      200: {
+        schema: ChainInfo
+      }
+    }
+  }
+  safe_apps_read: {
+    parameters: {
+      path: {
+        /** A unique value identifying this chain. */
+        chainId: string
+      }
+    }
+    responses: {
+      200: {
+        schema: SafeAppsResponse
+      }
+    }
+  }
+  master_copies: {
+    parameters: {
+      path: {
+        /** A unique value identifying this chain. */
+        chainId: string
+      }
+    }
+    responses: {
+      200: {
+        schema: MasterCopyReponse
+      }
+    }
+  }
+  data_decoder: {
+    parameters: {
+      path: {
+        /** A unique value identifying this chain. */
+        chainId: string
+      }
+      body: DecodedDataRequest
+    }
+    responses: {
+      200: {
+        schema: DecodedDataResponse
+      }
+    }
+  }
+}

--- a/src/types/decoded-data.ts
+++ b/src/types/decoded-data.ts
@@ -1,3 +1,7 @@
+export type DecodedDataRequest = {
+  data: string
+}
+
 export type DecodedDataBasicParameter = {
   name: string
   type: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,18 @@ export type ErrorResponse = {
   message: string
 }
 
+function replaceParam(str: string, key: string, value: string): string {
+  return str.replace(new RegExp(`\\{${key}\\}`, 'g'), value)
+}
+
+export function insertParams(template: string, params?: Params): string {
+  return params
+    ? Object.keys(params).reduce((result: string, key) => {
+        return replaceParam(result, key, String(params[key]))
+      }, template)
+    : template
+}
+
 export function stringifyQuery(query?: Params): string {
   if (!query) {
     return ''

--- a/tests/endpoint.test.js
+++ b/tests/endpoint.test.js
@@ -14,7 +14,7 @@ jest.mock('../src/utils', () => {
 describe('callEndpoint', () => {
   it('should accept just a path', async () => {
     await expect(
-      callEndpoint('https://safe-client.staging.gnosisdev.com/v1/balances/supported-fiat-codes'),
+      callEndpoint('https://safe-client.staging.gnosisdev.com/v1', '/balances/supported-fiat-codes'),
     ).resolves.toEqual({ success: true })
 
     expect(fetchData).toHaveBeenCalledWith(
@@ -23,9 +23,36 @@ describe('callEndpoint', () => {
     )
   })
 
+  it('should accept a path param', async () => {
+    await expect(
+      callEndpoint('https://safe-client.staging.gnosisdev.com/v1', '/chains/4/safe/{address}', {
+        path: { address: '0x123' },
+      }),
+    ).resolves.toEqual({ success: true })
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://safe-client.staging.gnosisdev.com/v1/chains/4/safe/0x123',
+      undefined,
+    )
+  })
+
+  it('should accept several path params', async () => {
+    await expect(
+      callEndpoint('https://safe-client.staging.gnosisdev.com/v1', '/chains/4/balances/{address}/{currency}', {
+        path: { address: '0x123', currency: 'usd' },
+      }),
+    ).resolves.toEqual({ success: true })
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://safe-client.staging.gnosisdev.com/v1/chains/4/balances/0x123/usd',
+      undefined,
+    )
+  })
+
   it('should accept query params', async () => {
     await expect(
-      callEndpoint('https://safe-client.staging.gnosisdev.com/v1/chains/4/balances/0x123/usd', {
+      callEndpoint('https://safe-client.staging.gnosisdev.com/v1', '/chains/4/balances/{address}/{currency}', {
+        path: { address: '0x123', currency: 'usd' },
         query: { exclude_spam: true },
       }),
     ).resolves.toEqual({ success: true })
@@ -38,7 +65,8 @@ describe('callEndpoint', () => {
 
   it('should accept body', async () => {
     await expect(
-      callEndpoint('https://safe-client.staging.gnosisdev.com/v1/chains/4/transactions/0x123/propose', {
+      callEndpoint('https://safe-client.staging.gnosisdev.com/v1', '/chains/4/transactions/{safe_address}/propose', {
+        path: { safe_address: '0x123' },
         body: { test: 'test' },
       }),
     ).resolves.toEqual({ success: true })
@@ -52,8 +80,9 @@ describe('callEndpoint', () => {
   it('should accept a raw URL', async () => {
     await expect(
       callEndpoint(
-        'https://safe-client.staging.gnosisdev.com/v1/chains/4/balances/0x123/usd',
-        { query: { exclude_spam: true } },
+        'https://safe-client.staging.gnosisdev.com/v1',
+        '/chains/4/balances/{address}/{currency}',
+        { path: { address: '0x123', currency: 'usd' }, query: { exclude_spam: true } },
         '/test-url?raw=true',
       ),
     ).resolves.toEqual({ success: true })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,9 +1,21 @@
 import fetch from 'isomorphic-unfetch'
-import { fetchData, stringifyQuery } from '../src/utils'
+import { fetchData, insertParams, stringifyQuery } from '../src/utils'
 
 jest.mock('isomorphic-unfetch')
 
 describe('utils', () => {
+  describe('insertParams', () => {
+    it('should insert a param into a string', () => {
+      expect(insertParams('/{network}/safe/{address}', { address: '0x0' })).toBe('/{network}/safe/0x0')
+    })
+
+    it('should insert several params into a string', () => {
+      expect(insertParams('/{network}/safe/{address}', { address: '0x0', network: 'rinkeby' })).toBe(
+        '/rinkeby/safe/0x0',
+      )
+    })
+  })
+
   describe('stringifyQuery', () => {
     it('should stringify query params', () => {
       expect(stringifyQuery({ spam: true, page: 11, name: 'token', exclude: null })).toBe(


### PR DESCRIPTION
The previous removal off `paths`/`operations` typing reverts the practice of following OpenAPI. All tests, utils, etc. now follow it again.