### PR TITLE
Export master copy/decoded data types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export * from './types/safe-apps'
 export * from './types/transactions'
 export * from './types/chains'
 export * from './types/common'
+export * from './types/master-copies'
+export * from './types/decoded-data'
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 

--- a/src/types/master-copies.ts
+++ b/src/types/master-copies.ts
@@ -1,8 +1,3 @@
-export enum MasterCopyDeployer {
-  GNOSIS = 'Gnosis',
-  CIRCLES = 'Circles',
-}
-
 export type MasterCopyReponse = {
   address: string
   version: string


### PR DESCRIPTION
New types were included in the SDK but not exported.