### PR TITLE
Remove Safe transaction estimation versioning

### DIFF
--- a/e2e/post-safe-gas-estimation.test.ts
+++ b/e2e/post-safe-gas-estimation.test.ts
@@ -1,21 +1,9 @@
-import { postSafeGasEstimation, postSafeGasEstimationV2 } from '../src'
+import { postSafeGasEstimation } from '../src'
 import config from './config'
 
 describe('postSafeGasEstimation tests', () => {
   it('should post a safe gas estimation', async () => {
     const result = await postSafeGasEstimation(config.baseUrl, '4', '0x4f9BD57BCC68Bf7770429F137922B3afD23d83E7', {
-      to: '0x4f9BD57BCC68Bf7770429F137922B3afD23d83E7',
-      value: '1',
-      data: '0x',
-      operation: 0,
-    })
-
-    expect(result.safeTxGas).toBe('45006')
-    // Nonce should match any positive integer number over 0
-    expect(result.latestNonce).toBeGreaterThanOrEqual(0)
-  })
-  it('should post a safe gas estimation (v2)', async () => {
-    const result = await postSafeGasEstimationV2(config.baseUrl, '4', '0x4f9BD57BCC68Bf7770429F137922B3afD23d83E7', {
       to: '0x4f9BD57BCC68Bf7770429F137922B3afD23d83E7',
       value: '1',
       data: '0x',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
 import { callEndpoint } from './endpoint'
 import { operations } from './types/api'
-import {
-  SafeTransactionEstimation,
-  SafeTransactionEstimationV2,
-  TransactionDetails,
-  TransactionListPage,
-} from './types/transactions'
+import { SafeTransactionEstimation, TransactionDetails, TransactionListPage } from './types/transactions'
 import { FiatCurrencies, OwnedSafes, SafeBalanceResponse, SafeCollectibleResponse, SafeInfo } from './types/common'
 import { ChainListResponse, ChainInfo } from './types/chains'
 import { SafeAppsResponse } from './types/safe-apps'
@@ -120,7 +115,7 @@ export function getTransactionDetails(
 }
 
 /**
- * Request a gas estimate for a created transaction
+ * Request a gas estimate & recommmended tx nonce for a created transaction
  */
 export function postSafeGasEstimation(
   baseUrl: string,
@@ -128,21 +123,6 @@ export function postSafeGasEstimation(
   address: string,
   body: operations['post_safe_gas_estimation']['parameters']['body'],
 ): Promise<SafeTransactionEstimation> {
-  return callEndpoint(baseUrl, '/v1/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations', {
-    path: { chainId, safe_address: address },
-    body,
-  })
-}
-
-/**
- * Request a gas estimate & recommmended tx nonce for a created transaction
- */
-export function postSafeGasEstimationV2(
-  baseUrl: string,
-  chainId: string,
-  address: string,
-  body: operations['post_safe_gas_estimation_v2']['parameters']['body'],
-): Promise<SafeTransactionEstimationV2> {
   return callEndpoint(baseUrl, '/v2/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations', {
     path: { chainId, safe_address: address },
     body,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5,7 +5,6 @@ import {
   SafeTransactionEstimation,
   SafeTransactionEstimationRequest,
   TransactionListPage,
-  SafeTransactionEstimationV2,
 } from './transactions'
 import { ChainListResponse, ChainInfo } from './chains'
 import { SafeAppsResponse } from './safe-apps'
@@ -74,7 +73,7 @@ export interface paths {
       }
     }
   }
-  '/v1/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations': {
+  '/v2/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations': {
     /** This is actually supposed to be POST but it breaks our type paradise */
     get: operations['post_safe_gas_estimation']
     parameters: {
@@ -83,11 +82,6 @@ export interface paths {
         safe_address: string
       }
     }
-  }
-  '/v2/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations': {
-    /** This is actually supposed to be POST but it breaks our type paradise */
-    get: operations['post_safe_gas_estimation_v2']
-    parameters: paths['/v1/chains/{chainId}/safes/{safe_address}/multisig-transactions/estimations']['parameters']
   }
   '/v1/chains/{chainId}/transactions/{safe_address}/propose': {
     /** This is actually supposed to be POST but it breaks our type paradise */
@@ -294,14 +288,6 @@ export interface operations {
       404: unknown
       /** Safe address checksum not valid */
       422: unknown
-    }
-  }
-  post_safe_gas_estimation_v2: {
-    parameters: operations['post_safe_gas_estimation']['parameters']
-    responses: Omit<operations['post_safe_gas_estimation']['responses'], 200> & {
-      200: {
-        schema: SafeTransactionEstimationV2
-      }
     }
   }
   propose_transaction: {

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -328,12 +328,8 @@ export type SafeTransactionEstimationRequest = {
   operation: Operation
 }
 
+// CGW v2 response
 export type SafeTransactionEstimation = {
-  latestNonce: number
-  safeTxGas: string
-}
-
-export type SafeTransactionEstimationV2 = {
   currentNonce: number
   recommendedNonce: number
   safeTxGas: string


### PR DESCRIPTION
A separate v2 version for Safe transaction estimation was added yesterday, along with related types. As this is only being used in one place in `safe-react`, v1 is no longer needed and, as such, is removed and v2 used in place.