### PR TITLE
Fix `client_url` param casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -358,7 +358,7 @@ export interface operations {
         chainId: string
       }
       query?: {
-        clientUrl?: string
+        client_url?: string
       }
     }
     responses: {


### PR DESCRIPTION
The client gateway uses a snake case and not a camel case and I messed it up. Sorry