### PR TITLE
Fixed SafeAppsResponse types to avoid only 1 item array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/safe-apps.ts
+++ b/src/types/safe-apps.ts
@@ -30,4 +30,4 @@ export type SafeAppData = {
   accessControl: SafeAppsAccessControlPolicies
 }
 
-export type SafeAppsResponse = [SafeAppData]
+export type SafeAppsResponse = SafeAppData[]


### PR DESCRIPTION
Ticket: https://github.com/gnosis/safe-react-apps/issues/286

With the current SafeAppsResponse type we only accept arrays with 1 item:

Changed
```
export type SafeAppsResponse = [SafeAppData]
```

Into
```
export type SafeAppsResponse = SafeAppData[]
```
