### PR TITLE
chore: add `trustedDelegateCallTarget` transaction flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -265,6 +265,7 @@ export type TransactionData = {
   value: string | null
   operation: Operation
   addressInfoIndex: { [key: string]: AddressEx } | null
+  trustedDelegateCallTarget: boolean
 }
 
 export type ModuleExecutionDetails = {


### PR DESCRIPTION
## Description

In accordance with the new `trustedDelegateCallTarget` flag [added to the transaction data](https://github.com/gnosis/safe-client-gateway/issues/725), this has been added to the `TransactionData` type.