### PR TITLE
fix: remove redundant status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -40,7 +40,6 @@ export enum TransactionStatus {
   FAILED = 'FAILED',
   SUCCESS = 'SUCCESS',
   PENDING = 'PENDING',
-  PENDING_FAILED = 'PENDING_FAILED',
   WILL_BE_REPLACED = 'WILL_BE_REPLACED',
 }
 


### PR DESCRIPTION
### Description

In fixing an isse with button text (https://github.com/gnosis/safe-react/issues/3352), it became apparent that the `PENDING_FAILED` (frontend-only) status was redundant and had been included in the Safe as a placeholder. This PR removes it to keep it inline with the frontend.