### PR TITLE
Add type property to TokenInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -279,6 +279,7 @@ export type MultisigConfirmation = {
 }
 
 export type TokenInfo = {
+  type: TokenType
   address: string
   decimals: number
   symbol: string


### PR DESCRIPTION
While adding the `safe-react-gateway-sdk` to the `safe-apps-sdk` to align in types I detected that this prop was missing and it's returned in the balances endpoint