### PR TITLE
feat: Use globalThis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.8.6",
+  "version": "2.9.0",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     path: dist,
     libraryTarget: 'umd',
     library: JSON.stringify(require('./package.json').name),
+    globalObject: 'this',
   },
   resolve: {
     extensions: ['.ts'],


### PR DESCRIPTION
## What it solves?

Resolves https://github.com/gnosis/safe-apps-sdk/issues/292

## How this is solved?

We are adding `globalThis` prop to the webpack config as the default `self`  in the compiled files is causing problems with SSR solutions as NextJS

