### PR TITLE
fix: TokenType for balances 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,8 @@
-import { AddressEx, TokenInfo } from './transactions'
+export type AddressEx = {
+  value: string
+  name: string | null
+  logoUri: string | null
+}
 
 export type SafeInfo = {
   address: AddressEx
@@ -19,6 +23,21 @@ export type SafeInfo = {
 export type FiatCurrencies = string[]
 
 export type OwnedSafes = { safes: string[] }
+
+export enum TokenType {
+  ERC20 = 'ERC20',
+  ERC721 = 'ERC721',
+  NATIVE_TOKEN = 'NATIVE_TOKEN',
+}
+
+export type TokenInfo = {
+  type: TokenType
+  address: string
+  decimals: number
+  symbol: string
+  name: string
+  logoUri: string | null
+}
 
 export type SafeBalanceResponse = {
   fiatTotal: string

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,3 +1,5 @@
+import { AddressEx, TokenInfo } from './common'
+
 export type ParamValue = string | ParamValue[]
 
 export enum Operation {
@@ -27,12 +29,6 @@ export type DataDecoded = {
   parameters: Parameter[] | null
 }
 
-export type AddressEx = {
-  value: string
-  name: string | null
-  logoUri: string | null
-}
-
 export enum TransactionStatus {
   AWAITING_CONFIRMATIONS = 'AWAITING_CONFIRMATIONS',
   AWAITING_EXECUTION = 'AWAITING_EXECUTION',
@@ -49,14 +45,14 @@ export enum TransferDirection {
   UNKNOWN = 'UNKNOWN',
 }
 
-export enum TokenType {
+export enum TransactionTokenType {
   ERC20 = 'ERC20',
   ERC721 = 'ERC721',
   NATIVE_COIN = 'NATIVE_COIN',
 }
 
 export type Erc20Transfer = {
-  type: TokenType.ERC20
+  type: TransactionTokenType.ERC20
   tokenAddress: string
   tokenName: string | null
   tokenSymbol: string | null
@@ -66,7 +62,7 @@ export type Erc20Transfer = {
 }
 
 export type Erc721Transfer = {
-  type: TokenType.ERC721
+  type: TransactionTokenType.ERC721
   tokenAddress: string
   tokenId: string
   tokenName: string | null
@@ -75,7 +71,7 @@ export type Erc721Transfer = {
 }
 
 export type NativeCoinTransfer = {
-  type: TokenType.NATIVE_COIN
+  type: TransactionTokenType.NATIVE_COIN
   value: string
 }
 
@@ -276,15 +272,6 @@ export type MultisigConfirmation = {
   signer: AddressEx
   signature: string | null
   submittedAt: number
-}
-
-export type TokenInfo = {
-  type: TokenType
-  address: string
-  decimals: number
-  symbol: string
-  name: string
-  logoUri: string | null
 }
 
 export type MultisigExecutionDetails = {


### PR DESCRIPTION
The client gateway returns NATIVE_TOKEN for TokenType enum and Transaction type uses NATIVE_COIN to define native chain token.

We should separate and not use the same TokenType to define both properties.

Also I made the transaction file to depend on the common that makes more sense

## Links
Resolves https://github.com/gnosis/safe-react-apps/issues/355