### PR TITLE
fix: add `setGuard`/`deleteGuard` types

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -128,6 +128,15 @@ export type DisableModule = {
   module: AddressEx
 }
 
+export type SetGuard = {
+  type: 'SET_GUARD'
+  guard: AddressEx
+}
+
+export type DeleteGuard = {
+  type: 'DELETE_GUARD'
+}
+
 export type SettingsInfo =
   | SetFallbackHandler
   | AddOwner


### PR DESCRIPTION
## What it solves
Resolves #64 64

## How this PR fixes it
In accordance with the [new `SettingsInfo` `setGuard`/`deleteGuard` types](https://gnosis.github.io/safe-client-gateway/docs/routes/transactions/models/enum.SettingsInfo.html), the transaction types have been extended.