### PR TITLE
feat: add tags to SafeAppData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/safe-apps.ts
+++ b/src/types/safe-apps.ts
@@ -28,6 +28,7 @@ export type SafeAppData = {
   chainIds: string[]
   provider?: SafeAppProvider
   accessControl: SafeAppsAccessControlPolicies
+  tags: string[]
 }
 
 export type SafeAppsResponse = SafeAppData[]


### PR DESCRIPTION
Add the `tags` property to
`https://gnosis.github.io/safe-client-gateway/docs/routes/safe_apps/routes/fn.get_safe_apps.html`
response given https://github.com/gnosis/safe-config-service/pull/496