### PR TITLE
fix: add least-privilege permissions and pin actions to SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - run: yarn install --immutable
 
@@ -18,7 +23,7 @@ jobs:
         continue-on-error: true
 
       - name: Annotate code with linting results
-        uses: ataylorme/eslint-annotate-action@v3
+        uses: ataylorme/eslint-annotate-action@21a1ba0738d8b732639999029c4ff40b6e121bb4 # v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           report-json: "eslint_report.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   publish-github:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 
@@ -36,7 +39,7 @@ jobs:
 
       - name: GitHub release
         if: env.NEW_VERSION != env.OLD_VERSION
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         id: create_release
         with:
           draft: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,16 +5,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - run: yarn install --immutable
 
       - name: Run tests
-        uses: mattallty/jest-github-action@v1
+        uses: mattallty/jest-github-action@40eafe1b6e3924992dd7e3b0a07e70dfdff1d52f # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -5,14 +5,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   typedoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
 
       - run: yarn install --immutable
 
@@ -20,7 +23,7 @@ jobs:
         run: ./node_modules/.bin/typedoc --githubPages src
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@5dc1d5a192aeb5ab5b7d5a77b7d36aea4a7f5c92 # 4.1.4
         with:
           branch: gh-pages
           folder: docs


### PR DESCRIPTION
Resolves four `actions/missing-workflow-permissions` warnings and the org SHA-pin policy.

Permissions:
- `lint.yml`: `checks`/`pull-requests: write` for `ataylorme/eslint-annotate-action`, `contents: read` for checkout.
- `release.yml`: `contents: write` to push the tag and create the release.
- `typedoc.yml`: `contents: write` to deploy to `gh-pages`.
- `test.yml`: `checks`/`pull-requests: write` for `mattallty/jest-github-action`, `contents: read` for checkout.

Pinned every external action ref to the SHA of the existing tag (or branch HEAD for `v6`-style major-version pointers) to preserve current behavior.
